### PR TITLE
More natural syntax.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,4 @@ Lead
 Contributors
 ------------
 
-None
+- Szczepan Cieślik, szczepan.cieslik@gmail.com, `beregond@github <https://github.com/beregond>`_

--- a/README.rst
+++ b/README.rst
@@ -132,13 +132,17 @@ All assertions can be also used in snake case format:
     # The same as:
     expect(value).NotIn(some_set)
 
-Two assertions are special cases: ``Not`` and ``Predicate``. ``Not`` is
-available through ``does_not`` and ``Predicate`` is available through ``does``:
+There are special cases:
+
+* ``Not`` is available through ``does_not``
+* ``Predicate`` is available through ``does``
+* ``Is`` is available through ``is_``
+* ``In`` is available through ``in_``
 
 .. code-block:: python
 
     def have_access_rights(user):
-        assert user.is_admin is True
+        return user.is_admin is True
 
     expect(user).does(have_access_rights)
     # Equal to:
@@ -147,6 +151,14 @@ available through ``does_not`` and ``Predicate`` is available through ``does``:
     expect(user).does_not(have_access_rights)
     # Equal to:
     expect(user).Not(have_access_rights)
+
+    ensure(some_value).in_(some_set)
+    # Equal to:
+    ensure(some_value).In(some_set)
+
+    ensure(result).is_(MyClass)
+    # Equal to:
+    ensure(result).Is(MyClass)
 
 
 Reserved names

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ prefixes ``to_be_*`` or ``is_*``:
     # Both above lines are the same as:
     expect(some_var).Int().LessOrEqual(5).NotList()
 
-All assertions can be also used as lowercased methods:
+All assertions can be also used in snake case format:
 
 .. code-block:: python
 
@@ -152,7 +152,7 @@ available through ``does_not`` and ``Predicate`` is available through ``does``:
 Reserved names
 --------------
 
-Things that doesn't work as expected:
+Things that don't work as expected:
 
 .. code-block:: python
 
@@ -167,7 +167,7 @@ All of the validators in ``verify`` are callables that can be used in two contex
 1. By themselves as in ``Equal(a, b)`` which will raise an ``AssertionError`` if false.
 2. In combination with ``expect`` as in ``expect(a, Equal(b))`` which could also raise an ``AssertionError``.
 
-The available validators           are:
+The available validators are:
 
 =================================== ===========
 Validator                           Description

--- a/README.rst
+++ b/README.rst
@@ -132,10 +132,10 @@ All assertions can be also used in snake case format:
     # The same as:
     expect(value).NotIn(some_set)
 
-There are special cases:
+There are few special cases:
 
-* ``Not`` is available through ``does_not``
-* ``Predicate`` is available through ``does``
+* ``Not`` is available through ``does_not``, ``fails`` and ``to_fail``
+* ``Predicate`` is available through ``does``, ``passes`` and ``to_pass``
 * ``Is`` is available through ``is_``
 * ``In`` is available through ``in_``
 
@@ -145,10 +145,14 @@ There are special cases:
         return user.is_admin is True
 
     expect(user).does(have_access_rights)
+    expect(user).to_pass(have_access_rights)
+    ensure(user).passes(have_access_rights)
     # Equal to:
     expect(user).Predicate(have_access_rights)
 
     expect(user).does_not(have_access_rights)
+    expect(user).to_fail(have_access_rights)
+    ensure(user).fails(have_access_rights)
     # Equal to:
     expect(user).Not(have_access_rights)
 

--- a/README.rst
+++ b/README.rst
@@ -116,83 +116,83 @@ All of the validators in ``verify`` are callables that can be used in two contex
 1. By themselves as in ``Equal(a, b)`` which will raise an ``AssertionError`` if false.
 2. In combination with ``expect`` as in ``expect(a, Equal(b))`` which could also raise an ``AssertionError``.
 
-The available validators are:
+The available validators           are:
 
-======================  ===========
-Validator               Description
-======================  ===========
-``Truthy``              Assert that ``bool(a)``.
-``Falsy``               Assert that ``not bool(a)``.
-``Not``                 Assert that a callable doesn't raise an ``AssertionError``.
-``Predicate``           Assert that ``predicate(a)``.
-``All``                 Assert that all of the list of predicates evaluate ``a`` as truthy.
-``NotAll``              Assert ``not All``.
-``Any``                 Assert that any of the list of predicates evaluate ``a`` as truthy.
-``NotAny``              Assert ``not Any``.
-``Equal``               Assert that ``a == b``.
-``NotEqual``            Assert ``not Equal``.
-``Match``               Assert that ``a`` matches regular expression ``b``.
-``NotMatch``            Assert ``not Match``.
-``Is``                  Assert that ``a is b``.
-``IsNot``               Assert ``not Is``.
-``IsTrue``              Assert that ``a is True``.
-``IsNotTrue``           Assert ``not IsTrue``.
-``IsFalse``             Assert that ``a is False``.
-``IsNotFalse``          Assert ``not IsFalse``.
-``IsNone``              Assert that ``a is None``.
-``IsNotNone``           Assert ``not IsNone``.
-``Type``                Assert that ``isinstance(a, b)``.
-``NotType``             Assert ``not Type``.
-``Boolean``             Assert that ``isinstance(a, bool)``.
-``NotBoolean``          Assert ``not Boolean``.
-``String``              Assert that ``isinstance(a, (str, unicode))``.
-``NotString``           Assert ``not String``.
-``Dict``                Assert that ``isinstance(a, dict)``.
-``NotDict``             Assert ``not Dict``.
-``List``                Assert that ``isinstance(a, list)``.
-``NotList``             Assert ``not List``.
-``Tuple``               Assert that ``isinstance(a, tuple)``.
-``NotTuple``            Assert ``not Tuple``.
-``Date``                Assert that ``isinstance(a, datetime.date)``.
-``NotDate``             Assert ``not Date``.
-``DateString``          Assert that ``a`` matches the datetime format string ``b``.
-``NotDateString``       Assert ``not DateString``.
-``Int``                 Assert that ``isinstance(a, int)``.
-``NotInt``              Assert ``not Int``.
-``Float``               Assert that ``isinstance(a, float)``.
-``NotFloat``            Assert ``not Float``.
-``Number``              Assert that ``isinstance(a, (int, float, Decimal, long))``.
-``NotNumber``           Assert ``not Number``.
-``In``                  Assert that ``a in b``.
-``NotIn``               Assert ``not In``.
-``Contains``            Assert that ``b in a``.
-``NotContains``         Assert ``not Contains``.
-``ContainsOnly``        Assert that values from ``b`` are the only ones contained in ``a``.
-``NotContainsOnly``     Assert ``not ContainsOnly``.
-``Subset``              Assert that ``a`` is a subset of ``b``.
-``NotSubset``           Assert ``not Subset``.
-``Superset``            Assert that ``a`` is a superset of ``b``.
-``NotSuperset``         Assert ``not Superset``.
-``Unique``              Assert that ``a`` contains unique items.
-``NotUnique``           Assert ``not Unique``.
-``Length``              Assert that ``b <= len(a) <= c``.
-``NotLength``           Assert that ``not Length``.
-``Greater``             Assert that ``a > b``.
-``GreaterEqual``        Assert that ``a >= b``.
-``Less``                Assert that ``a < b``.
-``LessEqual``           Assert that ``a <= b``.
-``Between``             Assert that ``b <= a <= c``.
-``NotBetween``          Assert ``not Between``.
-``Positive``            Assert that ``a > 0``.
-``Negative``            Assert that ``a < 0``.
-``Even``                Assert that ``a % 2 == 0``.
-``Odd``                 Assert that ``a % 2 != 1``.
-``Monotone``            Assert that ``a`` is monotonic with respect to ``b()``.
-``Increasing``          Assert that ``a`` is monotonically increasing.
-``StrictlyIncreasing``  Assert that ``a`` is strictly increasing.
-``Decreasing``          Assert that ``a`` is monotonically decreasing.
-``StrictlyDecreasing``  Assert that ``a`` is strictly decreasing.
-======================  ===========
+=================================== ===========
+Validator                           Description
+=================================== ===========
+``Truthy``                          Assert that ``bool(a)``.
+``Falsy``                           Assert that ``not bool(a)``.
+``Not``                             Assert that a callable doesn't raise an ``AssertionError``.
+``Predicate``                       Assert that ``predicate(a)``.
+``All``                             Assert that all of the list of predicates evaluate ``a`` as truthy.
+``NotAll``                          Assert ``not All``.
+``Any``                             Assert that any of the list of predicates evaluate ``a`` as truthy.
+``NotAny``                          Assert ``not Any``.
+``Equal``                           Assert that ``a == b``.
+``NotEqual``                        Assert ``not Equal``.
+``Match``                           Assert that ``a`` matches regular expression ``b``.
+``NotMatch``                        Assert ``not Match``.
+``Is``                              Assert that ``a is b``.
+``IsNot``                           Assert ``not Is``.
+``IsTrue``                          Assert that ``a is True``.
+``IsNotTrue``                       Assert ``not IsTrue``.
+``IsFalse``                         Assert that ``a is False``.
+``IsNotFalse``                      Assert ``not IsFalse``.
+``IsNone``                          Assert that ``a is None``.
+``IsNotNone``                       Assert ``not IsNone``.
+``Type``                            Assert that ``isinstance(a, b)``.
+``NotType``                         Assert ``not Type``.
+``Boolean``                         Assert that ``isinstance(a, bool)``.
+``NotBoolean``                      Assert ``not Boolean``.
+``String``                          Assert that ``isinstance(a, (str, unicode))``.
+``NotString``                       Assert ``not String``.
+``Dict``                            Assert that ``isinstance(a, dict)``.
+``NotDict``                         Assert ``not Dict``.
+``List``                            Assert that ``isinstance(a, list)``.
+``NotList``                         Assert ``not List``.
+``Tuple``                           Assert that ``isinstance(a, tuple)``.
+``NotTuple``                        Assert ``not Tuple``.
+``Date``                            Assert that ``isinstance(a, datetime.date)``.
+``NotDate``                         Assert ``not Date``.
+``DateString``                      Assert that ``a`` matches the datetime format string ``b``.
+``NotDateString``                   Assert ``not DateString``.
+``Int``                             Assert that ``isinstance(a, int)``.
+``NotInt``                          Assert ``not Int``.
+``Float``                           Assert that ``isinstance(a, float)``.
+``NotFloat``                        Assert ``not Float``.
+``Number``                          Assert that ``isinstance(a, (int, float, Decimal, long))``.
+``NotNumber``                       Assert ``not Number``.
+``In``                              Assert that ``a in b``.
+``NotIn``                           Assert ``not In``.
+``Contains``                        Assert that ``b in a``.
+``NotContains``                     Assert ``not Contains``.
+``ContainsOnly``                    Assert that values from ``b`` are the only ones contained in ``a``.
+``NotContainsOnly``                 Assert ``not ContainsOnly``.
+``Subset``                          Assert that ``a`` is a subset of ``b``.
+``NotSubset``                       Assert ``not Subset``.
+``Superset``                        Assert that ``a`` is a superset of ``b``.
+``NotSuperset``                     Assert ``not Superset``.
+``Unique``                          Assert that ``a`` contains unique items.
+``NotUnique``                       Assert ``not Unique``.
+``Length``                          Assert that ``b <= len(a) <= c``.
+``NotLength``                       Assert that ``not Length``.
+``Greater``/``GreaterThan``         Assert that ``a > b``.
+``GreaterEqual``/``GreaterOrEqual`` Assert that ``a >= b``.
+``Less``/``LessThan``               Assert that ``a < b``.
+``LessEqual``/``LessOrEqual``       Assert that ``a <= b``.
+``Between``                         Assert that ``b <= a <= c``.
+``NotBetween``                      Assert ``not Between``.
+``Positive``                        Assert that ``a > 0``.
+``Negative``                        Assert that ``a < 0``.
+``Even``                            Assert that ``a % 2 == 0``.
+``Odd``                             Assert that ``a % 2 != 1``.
+``Monotone``                        Assert that ``a`` is monotonic with respect to ``b()``.
+``Increasing``                      Assert that ``a`` is monotonically increasing.
+``StrictlyIncreasing``              Assert that ``a`` is strictly increasing.
+``Decreasing``                      Assert that ``a`` is monotonically decreasing.
+``StrictlyDecreasing``              Assert that ``a`` is strictly decreasing.
+=================================== ===========
 
 
 For more details, please see the full documentation at http://verify.readthedocs.org.

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,57 @@ And if you'd prefer to see ``assert`` being used, all ``verify`` assertions will
     assert Truthy(1)
     assert expect(1, Truthy(), Number())
 
+More natural syntax
+===================
+
+You can also use more natural syntax using ``ensure`` alias for ``expect`` and
+prefixes ``to_be_*`` or ``is_*``:
+
+.. code-block:: python
+
+    expect(some_var).to_be_int().to_be_less_or_equal(5).to_be_not_list()
+    ensure(some_var).is_int().is_less_or_equal(5).is_not_list()
+    # Both above lines are the same as:
+    expect(some_var).Int().LessOrEqual(5).NotList()
+
+All assertions can be also used as lowercased methods:
+
+.. code-block:: python
+
+    expect(value).contains(5)
+    # The same as:
+    expect(value).Contains(5)
+
+    expect(value).not_in(some_set)
+    # The same as:
+    expect(value).NotIn(some_set)
+
+Two assertions are special cases: ``Not`` and ``Predicate``. ``Not`` is
+available through ``does_not`` and ``Predicate`` is available through ``does``:
+
+.. code-block:: python
+
+    def have_access_rights(user):
+        assert user.is_admin is True
+
+    expect(user).does(have_access_rights)
+    # Equal to:
+    expect(user).Predicate(have_access_rights)
+
+    expect(user).does_not(have_access_rights)
+    # Equal to:
+    expect(user).Not(have_access_rights)
+
+
+Reserved names
+--------------
+
+Things that doesn't work as expected:
+
+.. code-block:: python
+
+    expect(value).is_not(predicate)  # translated into IsNot assertion
+    expect('v').in('verify')  # syntax error, try `to_be_in`
 
 Validators
 ==========

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,9 @@ Assertion Runner
 
 The :class:`.expect` class is basically an assertion runner that takes an input `value` and passes it through any number of assertions or predicate functions. If all assertions pass **and** return truthy, then all is well and ``True`` is returned. Otherwise, either one of the assertion functions will raise an ``AssertionError`` or no exceptiosn were raised but at least one of the functions returned a non-truthy value which means that :func:`.expect` will return ``False``.
 
+The :class:`.expect` has alias in the same module under name of ``ensure``, so
+you can use both of these names according to your needs.
+
 .. autoclass:: verify.runners.expect
     :members:
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -108,6 +108,11 @@ def test_expect_chain_invalid_method():
         expect(None).nosuchmethod
 
 
+def test_expect_chain_not_assertion():
+    with pytest.raises(AttributeError):
+        expect(None).expect
+
+
 @pytest.mark.parametrize('meth,value,arg',
                          METHOD_CALL_CASES,
                          ids=make_parametrize_id)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -59,6 +59,50 @@ def test_expect_chain_method_proxy():
         assert getattr(v, method) is getattr(expect(None), method).assertion
 
 
+def test_expect_chain_method_proxy_in_method_format():
+    for method in [method for method in v.__all__ if method[0].isupper()]:
+        method_name = _method_format(method)
+        chained_assertion = getattr(expect(None), method_name)
+        assert getattr(v, method) is chained_assertion.assertion
+
+
+def test_expect_chain_method_proxy_in_method_format_with_to_be_prefix():
+    for method in [method for method in v.__all__ if method[0].isupper()]:
+        method_name = 'to_be_' + _method_format(method)
+        chained_assertion = getattr(expect(None), method_name)
+        assert getattr(v, method) is chained_assertion.assertion
+
+
+def test_does_assertion():
+    chained_assertion = expect(None).does
+    assert chained_assertion.assertion is v.Predicate
+
+
+def test_does_not_assertion():
+    chained_assertion = expect(None).does_not
+    assert chained_assertion.assertion is v.Not
+
+
+def test_expect_chain_method_proxy_in_method_format_with_is_prefix():
+    for method in [method for method in v.__all__ if method[0].isupper()]:
+        if method == 'Not':
+            # Name mismatch, is_not is translated to IsNot assertion.
+            continue
+        method_name = 'is_' + _method_format(method)
+        chained_assertion = getattr(expect(None), method_name)
+        assert getattr(v, method) is chained_assertion.assertion
+
+
+def _method_format(name):
+    result = []
+    for letter in name:
+        if letter.isupper():
+            result.append('_' + letter.lower())
+        else:
+            result.append(letter)
+    return ''.join(result)[1:]
+
+
 def test_expect_chain_invalid_method():
     with pytest.raises(AttributeError):
         expect(None).nosuchmethod

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -83,6 +83,16 @@ def test_does_not_assertion():
     assert chained_assertion.assertion is v.Not
 
 
+def test_is_assertion():
+    chained_assertion = expect(None).is_
+    assert chained_assertion.assertion is v.Is
+
+
+def test_in_assertion():
+    chained_assertion = expect(None).in_
+    assert chained_assertion.assertion is v.In
+
+
 def test_expect_chain_method_proxy_in_method_format_with_is_prefix():
     for method in [method for method in v.__all__ if method[0].isupper()]:
         if method == 'Not':

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -73,24 +73,15 @@ def test_expect_chain_method_proxy_in_method_format_with_to_be_prefix():
         assert getattr(v, method) is chained_assertion.assertion
 
 
-def test_does_assertion():
-    chained_assertion = expect(None).does
-    assert chained_assertion.assertion is v.Predicate
-
-
-def test_does_not_assertion():
-    chained_assertion = expect(None).does_not
-    assert chained_assertion.assertion is v.Not
-
-
-def test_is_assertion():
-    chained_assertion = expect(None).is_
-    assert chained_assertion.assertion is v.Is
-
-
-def test_in_assertion():
-    chained_assertion = expect(None).in_
-    assert chained_assertion.assertion is v.In
+def test_special_aliases():
+    assert expect(None).does.assertion is v.Predicate
+    assert ensure(None).passes.assertion is v.Predicate
+    assert expect(None).to_pass.assertion is v.Predicate
+    assert expect(None).does_not.assertion is v.Not
+    assert ensure(None).fails.assertion is v.Not
+    assert expect(None).to_fail.assertion is v.Not
+    assert expect(None).is_.assertion is v.Is
+    assert expect(None).in_.assertion is v.In
 
 
 def test_expect_chain_method_proxy_in_method_format_with_is_prefix():

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -143,12 +143,12 @@ def test_assert_raises(meth, value, arg):
     assert opts['msg'] in str(exc.value)
 
 
-def test_expect_and_ensure_are_aliases():
-    assert expect is ensure
-
-
-def test_assertions_aliases():
-    assert v.Greater is v.GreaterThan
-    assert v.GreaterEqual is v.GreaterOrEqual
-    assert v.Less is v.LessThan
-    assert v.LessEqual is v.LessOrEqual
+@pytest.mark.parametrize('obj,alias', [
+    (expect, ensure),
+    (v.Greater, v.GreaterThan),
+    (v.GreaterEqual, v.GreaterOrEqual),
+    (v.Less, v.LessThan),
+    (v.LessEqual, v.LessOrEqual),
+])
+def test_aliases(obj, alias):
+    assert obj is alias

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -140,3 +140,10 @@ def test_assert_raises(meth, value, arg):
 
 def test_expect_and_ensure_are_aliases():
     assert expect is ensure
+
+
+def test_assertions_aliases():
+    assert v.Greater is v.GreaterThan
+    assert v.GreaterEqual is v.GreaterOrEqual
+    assert v.Less is v.LessThan
+    assert v.LessEqual is v.LessOrEqual

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -4,7 +4,7 @@ import pytest
 import pydash
 
 import verify as v
-from verify import expect
+from verify import expect, ensure
 
 from .fixtures import (
     METHOD_CALL_CASES,
@@ -92,3 +92,7 @@ def test_assert_raises(meth, value, arg):
         meth(value, *arg.args, **opts)
 
     assert opts['msg'] in str(exc.value)
+
+
+def test_expect_and_ensure_are_aliases():
+    assert expect is ensure

--- a/verify/__init__.py
+++ b/verify/__init__.py
@@ -158,9 +158,13 @@ from .containers import (
 
 from .numbers import (
     Greater,
+    GreaterThan,
     GreaterEqual,
+    GreaterOrEqual,
     Less,
+    LessThan,
     LessEqual,
+    LessOrEqual,
     Between,
     NotBetween,
     Positive,

--- a/verify/__init__.py
+++ b/verify/__init__.py
@@ -176,6 +176,7 @@ from .numbers import (
 
 from .runners import (
     expect,
+    ensure,
 )
 
 

--- a/verify/base.py
+++ b/verify/base.py
@@ -121,12 +121,8 @@ def is_assertion(obj):
     """Return whether `obj` is either an instance or subclass of
     :class:`Assertion`.
     """
-    is_instance = isinstance(obj, Assertion)
-
     try:
-        is_subclass = issubclass(obj, Assertion)
+        return isinstance(obj, Assertion) or issubclass(obj, Assertion)
     except TypeError:
         # Happens if `obj` isn't a class.
-        is_subclass = False
-
-    return is_instance or is_subclass
+        return False

--- a/verify/numbers.py
+++ b/verify/numbers.py
@@ -10,9 +10,13 @@ from .base import Assertion, Comparator, Negate, NotSet
 
 __all__ = (
     'Greater',
+    'GreaterThan',
     'GreaterEqual',
+    'GreaterOrEqual',
     'Less',
+    'LessThan',
     'LessEqual',
+    'LessOrEqual',
     'Between',
     'NotBetween',
     'Positive',
@@ -37,6 +41,9 @@ class Greater(Comparator):
     op = operator.gt
 
 
+GreaterThan = Greater
+
+
 class GreaterEqual(Comparator):
     """Asserts that `value` is greater than or equal to `comparable`.
 
@@ -45,6 +52,9 @@ class GreaterEqual(Comparator):
     #:
     reason = '{0} is not greater than or equal to {comparable}'
     op = operator.ge
+
+
+GreaterOrEqual = GreaterEqual
 
 
 class Less(Comparator):
@@ -57,6 +67,9 @@ class Less(Comparator):
     op = operator.lt
 
 
+LessThan = Less
+
+
 class LessEqual(Comparator):
     """Asserts that `value` is less than or equal to `comparable`.
 
@@ -65,6 +78,9 @@ class LessEqual(Comparator):
     #:
     reason = '{0} is not less than or equal to {comparable}'
     op = operator.le
+
+
+LessOrEqual = LessEqual
 
 
 class Between(Assertion):

--- a/verify/runners.py
+++ b/verify/runners.py
@@ -93,12 +93,12 @@ class expect(object):
             raise AttributeError(('"{0}" is not a valid assertion method'
                                   .format(attr)))
 
-        def chain(*args, **kargs):
+        def chained_assertion(*args, **kargs):
             assertion(*args, **kargs)(self.value)
             return self
-        chain.assertion = assertion
+        chained_assertion.assertion = assertion
 
-        return chain
+        return chained_assertion
 
     def __call__(self, *assertions):
         for assertion in assertions:
@@ -108,3 +108,6 @@ class expect(object):
                 assertion = verify.Predicate(assertion)
             assertion(self.value)
         return self
+
+
+ensure = expect

--- a/verify/runners.py
+++ b/verify/runners.py
@@ -118,7 +118,7 @@ ensure = expect
 def _find_assertion_class(name):
     try:
         return getattr(verify, name)
-    except AttributeError as original_error:
+    except AttributeError:
         pass
 
     name_formatters = [
@@ -138,7 +138,8 @@ def _find_assertion_class(name):
         except AttributeError:
             pass
 
-    raise original_error
+    raise AttributeError(('"{0}" is not a valid assertion method'
+                          .format(name)))
 
 
 def _class_format(name):

--- a/verify/runners.py
+++ b/verify/runners.py
@@ -161,7 +161,7 @@ def _prefixed_name(name, prefix):
 
 
 def _reserved_names(name):
-    if name == 'does':
+    if name in ['does', 'passes', 'to_pass']:
         return 'Predicate'
-    elif name == 'does_not':
+    elif name in ['does_not', 'fails', 'to_fail']:
         return 'Not'


### PR DESCRIPTION
What was done:
- `ensure` alias
- `to_be_*` and `is_*` aliases (except for `Not` assertion, because of name clash with `IsNot`)
- aliases for numeric assertions like `GreaterOrEqual`, since this way is much more simple for codebase (no weird `_or_` infixes handling)
- special methods `does` for `Predicate` and `does_not` for `Not` (also because of above reason)

Closes #7.
